### PR TITLE
Rebrand bot and switch to Finnish

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-	Thank you for contributing to Discord Tickets.
+        Kiitos, että osallistut dctickets.fi:n kehitykseen.
 	If you haven't already, please read the CONTRIBUTING guidelines (https://github.com/discord-tickets/.github/blob/main/CONTRIBUTING.md) before creating a pull request.
 	Unless this pull request is for something minor like a fixing a typo, you should create an issue first.
 -->

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -13,5 +13,4 @@ Release versions that will receive security updates.
 
 ## Reporting a vulnerability
 
-If you find a vulnerability, please use for the [security advisories form](https://github.com/discord-tickets/bot/security/advisories/new)
-or send an email to [contact@discordtickets.app](mailto:contact@discordtickets.app).
+Jos löydät haavoittuvuuden, käytä [turvaraportointilomaketta](https://dctickets.fi/security) tai lähetä sähköpostia osoitteeseen [contact@dctickets.fi](mailto:contact@dctickets.fi).

--- a/README.md
+++ b/README.md
@@ -1,157 +1,21 @@
-<div align="center">
+# dctickets.fi
 
-![bots](https://img.shields.io/badge/dynamic/json?color=5865F2&label=bots&query=combined.active.count&url=https%3A%2F%2Fstats.discordtickets.app%2Fapi%2Fv4%2Fcurrent&logo=discord&logoColor=white&style=for-the-badge)
-![tickets](https://img.shields.io/badge/dynamic/json?color=5865F2&label=tickets&query=combined.total.tickets&url=https%3A%2F%2Fstats.discordtickets.app%2Fapi%2Fv4%2Fcurrent&logo=discord&logoColor=white&style=for-the-badge)
-[![GitHub stars](https://img.shields.io/github/stars/discord-tickets/bot?style=for-the-badge)](https://github.com/discord-tickets/bot/stargazers)
-[![Codacy](https://img.shields.io/codacy/grade/b974eb5f984c40868e07d82c968bd02d?logo=codacy&amp;style=for-the-badge)](https://app.codacy.com/gh/discord-tickets/bot/dashboard)
-[![All Contributors](https://img.shields.io/github/all-contributors/discord-tickets/bot?color=ee8449&style=for-the-badge)](https://github.com/discord-tickets/bot/blob/main/CONTRIBUTORS.md)
-[![Discord](https://img.shields.io/discord/451745464480432129?label=discord&amp;color=7289DA&amp;style=for-the-badge)](https://lnk.earth/discord)
+dctickets.fi on avoimen lähdekoodin tikettibotti Discord-palvelimille. Se auttaa hallitsemaan tukipyyntöjä ja säilyttämään keskustelut.
 
-<br>
+## Asennus
 
-![Discord Tickets](https://static.eartharoid.me/discord-tickets/logo/wordmark/gradient-by-eartharoid.png)
+1. Kopioi repositorio ja asenna riippuvuudet
+   ```
+   pnpm install
+   ```
+2. Muokkaa `user/config.yml` tarpeidesi mukaan.
+3. Käynnistä botti komennolla
+   ```
+   npm start
+   ```
 
-**A free alternative to the premium and white-label plans of other ticket management bots.**
+## Lisätietoja
 
-<br>
-<a
-  href="https://www.producthunt.com/posts/discord-tickets?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-discord&#0045;tickets"
-  target="_blank">
-<img
-	src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=321112&theme=light"
-	alt="Discord&#0032;Tickets - A&#0032;free&#0032;ticketing&#0032;solution | Product Hunt"
-	style="width: 250px; height: 54px;"
-	width="250"
-	height="54"
-  />
-</a>
+Ohjeita ja lisämateriaalia löydät osoitteesta [dctickets.fi](https://dctickets.fi).
 
-<br>
-
----
-
-[![BisectHosting](https://www.bisecthosting.com/partners/custom-banners/41ca8074-184e-4ad1-a44d-77750ee8bfb9.webp)](https://bisecthosting.com/discordtickets)
-
-<a href="https://bisecthosting.com/discordtickets">Partnered with BisectHosting</a>
-<br>
-<sub>for affordable bot hosting</sub>
-
----
-
-<br>
-</div>
-
-## 📖 Contents
-
-- [📖 Contents](#-contents)
-- [✨ Features](#-features)
-  - [Want to learn more?](#want-to-learn-more)
-- [⚡ Getting started](#-getting-started)
-- [🤑 Sponsors](#-sponsors)
-- [🎖️ Contributors](#️-contributors)
-  - [💻 Contributing](#-contributing)
-    - [🌎 Translating](#-translating)
-- [😕 Support](#-support)
-- [⭐ Star History](#-star-history)
-- [🥱 License](#-license)
-
-
-## ✨ Features
-
-- 📖 [**Documentation**](https://discordtickets.app/getting-started/) - comprehensive documentation and guides to help you get started
-- ⚙️ **Simple settings** - configure your bot with the included and easy-to-use dashboard
-- 🎨 **Highly customisable** - tweak features, colours, messages, and more to your liking
-- 🛸 **Modern features** - including slash commands, buttons, select menus, and modals
-- 🤖 **Automation** - ease your staff team's workload with configurable automation
-  - 🏷️ [**Tags**](https://v4--discordtickets.netlify.app/features/#tags) - resolve members' problems without escalating to tickets
-  - 🎫 **Tickets** - close inactive tickets automatically
-- 📜 **Archiving** - store messages in the database and view transcripts later
-- ❓ **Context** - ask for a topic or up to 5 custom questions before creating a ticket, and see references to a message or previous ticket at a glance
-- 🗃️ **Organisation** - claim, release, move and transfer tickets between members and categories
-- 🌎 [**Internationalisation**](#-translating) - available in more than 10 languages
-- ⏱️ **Statistics** - analyse your staff members' performance
-- 🪓 **Battle-tested** - trusted by thousands of servers, with over [half a million tickets](https://stats.discordtickets.app/) created since 2019
-- 🐳 [**Docker**](https://discordtickets.app/self-hosting/installation/docker/) - reliable and quick deployment with Docker
-
-[*...and more!*](https://discordtickets.app/features/)
-
-### Want to learn more?
-
-**Visit [the website](https://discordtickets.app/) for more features, details, and screenshots**,
-or skip to the [full feature tour](https://discordtickets.app/features/).
-
-## ⚡ Getting started
-
-> *🙏 Please read the [documentation](https://discordtickets.app/self-hosting/installation/) before you start.*
-
-There are 3 ways to get started with Discord Tickets:
-
-- ☁️ [Add the public bot](https://discordtickets.app/public/) - instant setup, but branded *(great for testing)*
-- 😴 [Get a managed bot](https://discordtickets.app/managed/) - your own bot, hosted by me *(easy and cheap)*
-- 🧑‍💻 [Install your own bot](https://discordtickets.app/self-hosting/) - host it yourself *(experience recommended)*
-
-**[Read the documentation](https://discordtickets.app/getting-started/)** for more information.
-
-> This button is here because it looks nice, but I will cry if you click it before reading the [documentation](https://discordtickets.app/getting-started/). :)
-
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template/eB6TkX?referralCode=Z3aYd2)
-
-<!-- [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/discord-tickets/bot) -->
-
-## 🤑 Sponsors
-
-Discord Tickets is made possible by these awesome people and organisations:
-
-![Sponsors](https://cdn.jsdelivr.net/gh/eartharoid/sponsors/sponsorkit/sponsors-wide.svg)
-
-Please consider sponsoring the project if it adds value to your business/community.
-
-**[Sponsor on GitHub](https://github.com/discord-tickets/bot/?sponsor=1)**, or
-
-[![Donate at ko-fi](https://www.ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/eartharoid)
-
-> [!IMPORTANT]
-> **Ko-fi members are not listed.**
-> Sponsor through GitHub or a linked Patreon account to be listed above.
-> [Create a free organisation](https://github.com/account/organizations/new?plan=free)
-> to show your business or community's logo.
-
-## 🎖️ Contributors
-
-<!-- [![Contributors](https://contrib.rocks/image?repo=discord-tickets/bot)](https://github.com/discord-tickets/bot/graphs/contributors) -->
-
-Discord Tickets is made possible by all of the people listed in [CONTRIBUTORS.md](https://github.com/discord-tickets/bot/blob/main/CONTRIBUTORS.md).
-
-
-### 💻 Contributing
-
-If you want to help translate, suggest a feature, submit a bug report,
-or contribute in any other way, please read the [contributing guidelines](https://github.com/discord-tickets/.github/blob/main//CONTRIBUTING.md).
-
-> **Note**
-> You can add yourself to the list of contributors [here](https://github.com/discord-tickets/bot/issues/new/choose).
-
-#### 🌎 Translating
-
-[![Translation status](https://hosted.weblate.org/widgets/discord-tickets/-/open-graph.png)](https://hosted.weblate.org/engage/discord-tickets/)
-
-## 😕 Support
-
-[![Discord](https://discordapp.com/api/guilds/451745464480432129/widget.png?style=banner4)](https://lnk.earth/discord)
-
-## ⭐ Star History
-
-<details>
-  <summary>Show graph</summary>
-
-  [![Star History Chart](https://api.star-history.com/svg?repos=discord-tickets/bot&type=Date)](https://star-history.com/#discord-tickets/bot&Date)
-
-</details>
-
-## 🥱 License
-
-Discord Tickets by eartharoid™️ is licensed under the [GPLv3 license](https://github.com/discord-tickets/bot/blob/main/LICENSE).
-
-This is not an official Discord product. It is not affiliated with nor endorsed by Discord Inc.
-
-© 2023 Isaac Saunders
+Tämä projekti on julkaistu [GPLv3](https://www.gnu.org/licenses/gpl-3.0.html) -lisenssillä.

--- a/db/mysql/migrations/20230309144248_4_0_0/migration.sql
+++ b/db/mysql/migrations/20230309144248_4_0_0/migration.sql
@@ -100,7 +100,7 @@ CREATE TABLE `guilds` (
     `closeButton` BOOLEAN NOT NULL DEFAULT false,
     `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     `errorColour` VARCHAR(191) NOT NULL DEFAULT 'Red',
-    `footer` VARCHAR(191) NULL DEFAULT 'Discord Tickets by eartharoid',
+    `footer` VARCHAR(191) NULL DEFAULT 'dctickets.fi',
     `id` VARCHAR(19) NOT NULL,
     `locale` VARCHAR(191) NOT NULL DEFAULT 'en-GB',
     `logChannel` VARCHAR(19) NULL,

--- a/db/mysql/schema.prisma
+++ b/db/mysql/schema.prisma
@@ -122,7 +122,7 @@ model Guild {
     createdAt     DateTime   @default(now())
     errorColour   String     @default("Red")
     feedback      Feedback[]
-    footer        String?    @default("Discord Tickets by eartharoid")
+    footer        String?    @default("dctickets.fi")
     id            String     @id @db.VarChar(19)
     locale        String     @default("en-GB")
     logChannel    String?    @db.VarChar(19)

--- a/db/postgresql/migrations/20230309132703_4_0_0/migration.sql
+++ b/db/postgresql/migrations/20230309132703_4_0_0/migration.sql
@@ -103,7 +103,7 @@ CREATE TABLE "guilds" (
     "closeButton" BOOLEAN NOT NULL DEFAULT false,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "errorColour" TEXT NOT NULL DEFAULT 'Red',
-    "footer" TEXT DEFAULT 'Discord Tickets by eartharoid',
+    "footer" TEXT DEFAULT 'dctickets.fi',
     "id" VARCHAR(19) NOT NULL,
     "locale" TEXT NOT NULL DEFAULT 'en-GB',
     "logChannel" VARCHAR(19),

--- a/db/postgresql/schema.prisma
+++ b/db/postgresql/schema.prisma
@@ -121,7 +121,7 @@ model Guild {
     createdAt     DateTime   @default(now())
     errorColour   String     @default("Red")
     feedback      Feedback[]
-    footer        String?    @default("Discord Tickets by eartharoid")
+    footer        String?    @default("dctickets.fi")
     id            String     @id @db.VarChar(19)
     locale        String     @default("en-GB")
     logChannel    String?    @db.VarChar(19)

--- a/db/sqlite/migrations/20230309142817_4_0_0/migration.sql
+++ b/db/sqlite/migrations/20230309142817_4_0_0/migration.sql
@@ -101,7 +101,7 @@ CREATE TABLE "guilds" (
     "closeButton" BOOLEAN NOT NULL DEFAULT false,
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "errorColour" TEXT NOT NULL DEFAULT 'Red',
-    "footer" TEXT DEFAULT 'Discord Tickets by eartharoid',
+    "footer" TEXT DEFAULT 'dctickets.fi',
     "id" TEXT NOT NULL PRIMARY KEY,
     "locale" TEXT NOT NULL DEFAULT 'en-GB',
     "logChannel" TEXT,

--- a/db/sqlite/schema.prisma
+++ b/db/sqlite/schema.prisma
@@ -121,7 +121,7 @@ model Guild {
     createdAt     DateTime   @default(now())
     errorColour   String     @default("Red")
     feedback      Feedback[]
-    footer        String?    @default("Discord Tickets by eartharoid")
+    footer        String?    @default("dctickets.fi")
     id            String     @id
     locale        String     @default("en-GB")
     logChannel    String?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,8 @@ services:
       - /etc/localtime:/etc/localtime:ro
     tty: true
     stdin_open: true
-    # Please refer to the documentation:
-    # https://discordtickets.app/self-hosting/configuration/#environment-variables
+    # Katso ohjeet osoitteesta:
+    # https://dctickets.fi/self-hosting/#ymparisto
     environment:
       DB_CONNECTION_URL: mysql://tickets:insecure@mysql/tickets # change `insecure` to the MYSQL_PASSWORD you set above
       DISCORD_SECRET: # required

--- a/eggs/pelican.json
+++ b/eggs/pelican.json
@@ -5,10 +5,10 @@
         "update_url": null
     },
     "exported_at": "2025-02-02T14:27:20+00:00",
-    "name": "Discord Tickets Bot",
+    "name": "dctickets.fi Bot",
     "author": "git@astrid.email",
     "uuid": "38e959a0-f571-45a4-9288-2a7c960fa3c5",
-    "description": "The official egg for the Discord Tickets bot.",
+    "description": "Virallinen dctickets.fi -munatiedosto.",
     "features": null,
     "docker_images": {
         "4.0 (recommended)": "ghcr.io\/discord-tickets\/bot:4.0",
@@ -48,7 +48,7 @@
         },
         {
             "name": "Database URL",
-            "description": "Leave blank if using SQLite, but SQLite is not recommended in production.\r\nhttps:\/\/discordtickets.app\/self-hosting\/configuration\/#db_connection_url",
+            "description": "Jätä tyhjäksi jos käytät SQLitea. SQLitea ei suositella tuotannossa.\r\nhttps:\/\/dctickets.fi\/self-hosting\/configuration\/",
             "env_variable": "DB_CONNECTION_URL",
             "default_value": "",
             "user_viewable": true,

--- a/eggs/pterodactyl.json
+++ b/eggs/pterodactyl.json
@@ -5,9 +5,9 @@
 		"update_url": null
 	},
 	"exported_at": "2024-01-15T00:25:21+00:00",
-	"name": "Discord Tickets Bot",
+        "name": "dctickets.fi Bot",
 	"author": "contact@bisecthosting.com",
-	"description": "The official egg for the Discord Tickets bot.",
+        "description": "Virallinen dctickets.fi -munatiedosto.",
 	"features": null,
 	"docker_images": {
 		"4.0 (recommended)": "ghcr.io\/discord-tickets\/bot:4.0",
@@ -42,7 +42,7 @@
 		},
 		{
 			"name": "Database URL",
-			"description": "Leave blank if using SQLite, but SQLite is not recommended in production.\r\nhttps:\/\/discordtickets.app\/self-hosting\/configuration\/#db_connection_url",
+                        "description": "Jätä tyhjäksi jos käytät SQLitea. SQLitea ei suositella tuotannossa.\r\nhttps:\/\/dctickets.fi\/self-hosting\/configuration\/",
 			"env_variable": "DB_CONNECTION_URL",
 			"default_value": "",
 			"user_viewable": true,

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "discord-tickets",
+        "name": "dctickets-bot",
 	"version": "4.0.38",
 	"private": "true",
-	"description": "The most popular open-source ticket management bot for Discord.",
+        "description": "Avoimen lähdekoodin tikettibotti Discordiin.",
 	"main": "src/",
 	"scripts": {
 		"db.dump": "node scripts/dump.mjs",
@@ -30,10 +30,10 @@
 			"npm run lint --"
 		]
 	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/discord-tickets/bot.git"
-	},
+        "repository": {
+                "type": "git",
+                "url": "git+https://dctickets.fi/bot.git"
+        },
 	"keywords": [
 		"discord",
 		"tickets",
@@ -41,10 +41,10 @@
 	],
 	"author": "eartharoid",
 	"license": "GPL-3.0-or-later",
-	"bugs": {
-		"url": "https://github.com/discord-tickets/bot/issues"
-	},
-	"homepage": "https://discordtickets.app",
+        "bugs": {
+                "url": "https://dctickets.fi/issues"
+        },
+        "homepage": "https://dctickets.fi",
 	"engines": {
 		"node": ">=18"
 	},

--- a/src/client.js
+++ b/src/client.js
@@ -56,8 +56,8 @@ module.exports = class Client extends FrameworkClient {
 				locales[name] = YAML.parse(data);
 			});
 
-		/** @type {I18n} */
-		this.i18n = new I18n('en-GB', locales);
+                /** @type {I18n} */
+                this.i18n = new I18n('fi', locales);
 
 		// to maintain references, these shouldn't be reassigned
 		Object.assign(this.config, YAML.parse(fs.readFileSync('./user/config.yml', 'utf8')));

--- a/src/commands/slash/help.js
+++ b/src/commands/slash/help.js
@@ -45,10 +45,10 @@ module.exports = class ClaimSlashCommand extends SlashCommand {
 					inline: true,
 					name: getMessage('commands.slash.help.response.links.links'),
 					value: [
-						['commands', 'https://discordtickets.app/features/commands'],
-						['docs', 'https://discordtickets.app'],
-						['feedback', 'https://lnk.earth/dsctickets-feedback'],
-						['support', 'https://lnk.earth/discord'],
+                                                ['commands', 'https://dctickets.fi/komennot'],
+                                                ['docs', 'https://dctickets.fi'],
+                                                ['feedback', 'https://dctickets.fi/palaute'],
+                                                ['support', 'https://dctickets.fi/discord'],
 					]
 						.map(([l, url]) => `> [${getMessage('commands.slash.help.response.links.' + l)}](${url})`)
 						.join('\n'),
@@ -70,7 +70,7 @@ module.exports = class ClaimSlashCommand extends SlashCommand {
 					.setColor(settings.primaryColour)
 					.setTitle(getMessage('commands.slash.help.title'))
 					.setDescription(staff
-						? `**Discord Tickets v${version} by eartharoid.**`
+                                                ? `**dctickets.fi v${version}**`
 						: getMessage('commands.slash.help.response.description', { command: `</${newCommand.name}:${newCommand.id}>` }))
 					.setFields(fields),
 			],

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 /**
- * Discord Tickets
+ * dctickets.fi
  * Copyright (C) 2022 Isaac Saunders
  *
  * This program is free software: you can redistribute it and/or modify
@@ -15,8 +15,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- * @name discord-tickets/bot
- * @description An open-source Discord bot for ticket management
+ * @name dctickets.fi/bot
+ * @description Avoimen lähdekoodin tikettibotti Discordiin
  * @copyright 2022 Isaac Saunders
  * @license GNU-GPLv3
  */
@@ -47,7 +47,7 @@ if (base_dir !== cwd) {
 	}
 	console.log('  Base directory:    ' + colours.gray(base_dir));
 	console.log('  Current directory: ' + colours.gray(cwd));
-	console.log(colours.blueBright('  Learn more at https://lnk.earth/dt-cwd.'));
+        console.log(colours.blueBright('  Lisätietoja: https://dctickets.fi')); 
 }
 
 process.env.NODE_ENV ??= 'production'; // make sure NODE_ENV is set
@@ -73,7 +73,7 @@ process.on('SIGTERM', () => exit('SIGTERM'));
 process.on('SIGINT', () => exit('SIGINT'));
 
 process.on('uncaughtException', (error, origin) => {
-	log.notice(`Discord Tickets v${pkg.version} on Node.js ${process.version} (${process.platform})`);
+        log.notice(`dctickets.fi v${pkg.version} on Node.js ${process.version} (${process.platform})`);
 	log.warn(origin === 'uncaughtException' ? 'Uncaught exception' : 'Unhandled promise rejection' + ` (${error.name})`);
 	log.error(error);
 });

--- a/src/lib/banner.js
+++ b/src/lib/banner.js
@@ -4,17 +4,11 @@ const figlet = require('figlet');
 const link = require('terminal-link');
 
 module.exports = version => {
-	figlet
-		.textSync('Discord', { font: 'Banner3' })
-		.split('\n')
-		.forEach(line => console.log(colours.cyan(line)));
-	console.log('');
-	figlet
-		.textSync('Tickets', { font: 'Banner3' })
-		.split('\n')
-		.forEach(line => console.log(colours.cyan(line)));
-	console.log('');
-	console.log(colours.cyanBright(`${link('Discord Tickets', 'https://discordtickets.app')} bot v${version} by eartharoid`));
-	console.log(colours.cyanBright('Sponsor this project at https://discordtickets.app/sponsor'));
+        figlet
+                .textSync('dctickets.fi', { font: 'Banner3' })
+                .split('\n')
+                .forEach(line => console.log(colours.cyan(line)));
+        console.log('');
+        console.log(colours.cyanBright(`${link('dctickets.fi', 'https://dctickets.fi')} v${version}`));
 	console.log('\n');
 };

--- a/src/lib/error.js
+++ b/src/lib/error.js
@@ -55,7 +55,7 @@ module.exports.handleInteractionError = async event => {
 				.addFields([
 					{
 						name: getMessage('misc.role_error.fields.for_admins.name'),
-						value: getMessage('misc.role_error.fields.for_admins.value', { url: 'https://discordtickets.app/self-hosting/troubleshooting/#invalid-user-or-role' }),
+                                                value: getMessage('misc.role_error.fields.for_admins.value', { url: 'https://dctickets.fi/ohjeet/#invalid-user-or-role' }),
 					},
 				]),
 		);
@@ -68,7 +68,7 @@ module.exports.handleInteractionError = async event => {
 				.addFields([
 					{
 						name: getMessage('misc.permissions_error.fields.for_admins.name'),
-						value: getMessage('misc.permissions_error.fields.for_admins.value', { url: 'https://discordtickets.app/self-hosting/troubleshooting/#missing-permissions' }),
+                                                value: getMessage('misc.permissions_error.fields.for_admins.value', { url: 'https://dctickets.fi/ohjeet/#missing-permissions' }),
 					},
 				]),
 		);

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -7,7 +7,7 @@ const DTF = require('@eartharoid/dtf');
 const { short } = require('leeks.js');
 const { format } = require('util');
 
-const dtf = new DTF('en-GB');
+const dtf = new DTF('fi');
 const colours = {
 	critical: ['&!4&f', '&!4&f'],
 	debug: ['&1', '&9'],
@@ -44,7 +44,7 @@ module.exports = config => {
 				directory: config.logs.files.directory,
 				format: '[{timestamp}] [{LEVEL}] ({NAMESPACE}) @{file}:{line}:{column} {content}',
 				level: config.logs.level,
-				name: 'Discord Tickets by eartharoid',
+                                name: 'dctickets.fi',
 				timestamp: 'YYYY-MM-DD HH:mm:ss',
 			}),
 		);

--- a/src/lib/stats.js
+++ b/src/lib/stats.js
@@ -60,7 +60,7 @@ async function sendToHouston(client) {
 
 	try {
 		client.log.verbose('Reporting to Houston:', stats);
-		const res = await fetch('https://stats.discordtickets.app/api/v4/houston', {
+                const res = await fetch('https://stats.dctickets.fi/api/v4/houston', {
 			body: JSON.stringify(stats),
 			headers: { 'content-type': 'application/json' },
 			method: 'POST',

--- a/src/lib/updates.js
+++ b/src/lib/updates.js
@@ -6,7 +6,7 @@ const { version: currentVersion } = require('../../package.json');
 /** @param {import("client")} client */
 module.exports = client => {
 	client.log.info('Checking for updates...');
-	fetch('https://api.github.com/repos/discord-tickets/bot/releases')
+        fetch('https://api.github.com/repos/dctickets/bot/releases')
 		.then(res => res.json())
 		.then(async json => {
 			// releases are ordered by date, so a patch for an old version could be before the latest version
@@ -19,7 +19,7 @@ module.exports = client => {
 
 			switch (compared) {
 			case -1: {
-				client.log.notice('You are running a pre-release version of Discord Tickets');
+                                client.log.notice('Käytät dctickets.fi:n esijulkaisua');
 				break;
 			}
 			case 0: {
@@ -31,12 +31,12 @@ module.exports = client => {
 				if (currentRelease === -1) return client.log.warn('Failed to find current release');
 				const behind = currentRelease;
 				currentRelease = releases[currentRelease];
-				const changelog = `https://discordtickets.app/changelogs/v${latestVersion}/`;
-				const guide = 'https://discordtickets.app/self-hosting/updating/';
+                                const changelog = `https://dctickets.fi/changelogs/v${latestVersion}/`;
+                                const guide = 'https://dctickets.fi/paivitys/';
 				const { default: boxen } = await import('boxen');
 
-				client.log.notice(
-					short('&r&6A new version of Discord Tickets is available (&c%s&6 -> &a%s&6)&r\n'),
+                                client.log.notice(
+                                        short('&r&6Uusi versio saatavilla (&c%s&6 -> &a%s&6)&r\n'),
 					currentVersion,
 					latestVersion,
 					boxen(

--- a/src/listeners/client/ready.js
+++ b/src/listeners/client/ready.js
@@ -28,7 +28,7 @@ module.exports = class extends Listener {
 		/** @type {import("client")} */
 		const client = this.client;
 
-		// process.title = `"[Discord Tickets] ${client.user.tag}"`; // too long and gets cut off
+                // process.title = `"[dctickets.fi] ${client.user.tag}"`; // liian pitkä ja katkeaa
 		process.title = 'tickets';
 		client.log.success('Connected to Discord as "%s" over %d shards', client.user.tag, client.ws.shards.size);
 

--- a/src/stdin/help.js
+++ b/src/stdin/help.js
@@ -10,8 +10,8 @@ module.exports = class extends StdinCommand {
 	}
 
 	async run() {
-		this.client.log.info('Documentation:', homepage);
-		this.client.log.info('Support: https://lnk.earth/discord');
+                this.client.log.info('Dokumentaatio:', homepage);
+                this.client.log.info('Tuki: https://dctickets.fi/discord');
 		this.client.log.info('stdin commands:\n' + this.client.stdin.components.map(c => `> ${c.id}`).join('\n'));
 	}
 };

--- a/src/user/config.yml
+++ b/src/user/config.yml
@@ -10,8 +10,8 @@
 ##    | |   | | | (__  |   <  |  __/ | |_  \__ \   ##
 ##    |_|   |_|  \___| |_|\_\  \___|  \__| |___/   ##
 ##                                                 ##
-##    Documentation: https://discordtickets.app    ##
-##    Support:        https://lnk.earth/discord    ##
+##    Dokumentaatio:  https://dctickets.fi       ##
+##    Tuki:           https://dctickets.fi/discord ##
 #####################################################
 
 logs:


### PR DESCRIPTION
## Summary
- remove all old Discord Tickets branding
- rebrand references to **dctickets.fi**
- make default language Finnish
- update docs and configuration examples

## Testing
- `npm test` *(fails: Cannot find module 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6840129ac86483278243cfad1b6a5137